### PR TITLE
Fix issue #13: typo on line 30 in 0xcalculator/functions/calc.h

### DIFF
--- a/0xcalculator/functions/calc.h
+++ b/0xcalculator/functions/calc.h
@@ -27,5 +27,5 @@ double cosInv(double n);
 double tanInv(double n);
 double secant(double n);
 double cosecant(double n);
-double cotangent(doubl n);
+double cotangent(double n);
 #endif


### PR DESCRIPTION
The typo in 0xcalculator/functions/calc.h on line 30 is now fixed.
